### PR TITLE
fix: shadcn/ui および Tailwind CSS のスタイリング問題を修正 (fixes #1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -32,7 +33,6 @@
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
-        "tw-animate-css": "^1.3.5",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4",
@@ -4754,8 +4754,16 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -4954,16 +4962,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/tw-animate-css": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.5.tgz",
-      "integrity": "sha512-t3u+0YNoloIhj1mMXs779P6MO9q3p3mvGn4k1n3nJPqJw/glZcuijG2qTSN4z4mgNRfW5ZC3aXJFLwDtiipZXA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
@@ -54,7 +55,6 @@
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
-    "tw-animate-css": "^1.3.5",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -93,8 +93,8 @@ export function GameBoard({
       <div
         ref={boardRef}
         className={cn(
-          'relative bg-stone-100',
-          'focus:outline-none focus:ring-2 focus:ring-amber-500',
+          'relative bg-stone-100 border-4 border-black',
+          'focus:outline-none',
           'cursor-pointer'
         )}
         style={{
@@ -154,7 +154,7 @@ export function GameBoard({
         
         {/* Exit area */}
         <div
-          className="absolute bg-emerald-200 border-2 border-emerald-600 rounded-md flex items-center justify-center z-0"
+          className="absolute flex items-center justify-center z-0"
           style={exitStyle}
         >
           <span className="text-emerald-800 font-bold text-sm">出口</span>

--- a/src/components/GameControls.tsx
+++ b/src/components/GameControls.tsx
@@ -13,8 +13,8 @@ export function GameControls({ moves, canUndo, isWon, onUndo, onReset }: GameCon
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="flex items-center gap-6">
-        <div className="text-lg font-semibold">
-          手数: <span className="text-blue-600">{moves}</span>
+        <div className="text-lg font-semibold text-stone-800">
+          手数: <span className="text-blue-700 font-bold">{moves}</span>
         </div>
         
         {isWon && (
@@ -32,9 +32,7 @@ export function GameControls({ moves, canUndo, isWon, onUndo, onReset }: GameCon
           size="lg"
           className={cn(
             "mr-4",
-            canUndo && !isWon 
-              ? "bg-amber-500 hover:bg-amber-600 text-white border-amber-600" 
-              : "bg-gray-100 text-gray-400 border-gray-300 hover:bg-gray-100"
+            canUndo && !isWon ? "border-2 border-black" : ""
           )}
         >
           <span>↶</span>
@@ -43,9 +41,9 @@ export function GameControls({ moves, canUndo, isWon, onUndo, onReset }: GameCon
 
         <Button
           onClick={onReset}
-          variant="destructive"
+          variant="default"
           size="lg"
-          className="bg-red-500 hover:bg-red-600 text-white"
+          className="border-2 border-black"
         >
           <span>⟲</span>
           リセット

--- a/src/components/Handle.tsx
+++ b/src/components/Handle.tsx
@@ -69,11 +69,11 @@ export function Handle({ direction, isSelected, onClick, className }: HandleProp
         isSelected ? 'border-2 border-amber-600' : 'border-2 border-stone-400',
         'flex items-center justify-center',
         'font-black text-lg',
-        isSelected ? 'text-white' : 'text-stone-600',
+        isSelected ? 'text-stone-700' : 'text-stone-600',
         'z-20',
         isSelected 
-          ? 'bg-amber-500 hover:bg-amber-600 opacity-100'
-          : 'bg-stone-300 hover:bg-stone-400 active:bg-stone-500 opacity-100',
+          ? 'bg-amber-200 hover:bg-amber-300 opacity-100'
+          : 'bg-stone-200 hover:bg-stone-300 active:bg-stone-400 opacity-100',
         className
       )}
       style={getPositionStyle()}

--- a/src/components/Piece.tsx
+++ b/src/components/Piece.tsx
@@ -38,7 +38,7 @@ export function Piece({ piece, movableDirections, selectedDirections, onMove, ce
   const [lastMoveDirection, setLastMoveDirection] = useState<Direction | null>(null);
   const isDragging = useRef(false);
   
-  const gap = 1; // 1px gap between pieces
+  const gap = 0; // No gap between pieces
   const leftOffset = -3; // Move pieces left slightly
   const topOffset = -3; // Move pieces up slightly
   const style = {

--- a/src/index.css
+++ b/src/index.css
@@ -1,134 +1,77 @@
 
-@import "tw-animate-css";
+@import "tailwindcss";
 
-@custom-variant dark (&:is(.dark *));
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+@theme {
+  --radius: 0.5rem;
+  
+  /* Color definitions in v4 format */
+  --color-border: hsl(240 5.9% 90%);
+  --color-input: hsl(240 5.9% 90%);
+  --color-ring: hsl(240 5.9% 10%);
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(240 10% 3.9%);
+  --color-primary: hsl(240 9% 10%);
+  --color-primary-foreground: hsl(0 0% 98%);
+  --color-secondary: hsl(240 4.8% 95.9%);
+  --color-secondary-foreground: hsl(240 5.9% 10%);
+  --color-destructive: hsl(0 84.2% 60.2%);
+  --color-destructive-foreground: hsl(0 0% 98%);
+  --color-muted: hsl(240 4.8% 95.9%);
+  --color-muted-foreground: hsl(240 3.8% 46.1%);
+  --color-accent: hsl(240 4.8% 95.9%);
+  --color-accent-foreground: hsl(240 5.9% 10%);
+  --color-popover: hsl(0 0% 100%);
+  --color-popover-foreground: hsl(240 10% 3.9%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(240 10% 3.9%);
+  --color-chart-1: hsl(12 76% 61%);
+  --color-chart-2: hsl(173 58% 39%);
+  --color-chart-3: hsl(197 37% 24%);
+  --color-chart-4: hsl(43 74% 66%);
+  --color-chart-5: hsl(27 87% 67%);
 }
 
-
-@theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-}
-
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Dark theme colors */
+    --color-border: hsl(240 3.7% 25%);
+    --color-input: hsl(240 3.7% 15.9%);
+    --color-ring: hsl(240 4.9% 83.9%);
+    --color-background: hsl(240 10% 3.9%);
+    --color-foreground: hsl(0 0% 98%);
+    --color-primary: hsl(0 0% 98%);
+    --color-primary-foreground: hsl(240 5.9% 10%);
+    --color-secondary: hsl(240 3.7% 15.9%);
+    --color-secondary-foreground: hsl(0 0% 98%);
+    --color-destructive: hsl(0 62.8% 30.6%);
+    --color-destructive-foreground: hsl(0 0% 98%);
+    --color-muted: hsl(240 3.7% 15.9%);
+    --color-muted-foreground: hsl(240 5% 64.9%);
+    --color-accent: hsl(240 3.7% 15.9%);
+    --color-accent-foreground: hsl(0 0% 98%);
+    --color-popover: hsl(240 10% 3.9%);
+    --color-popover-foreground: hsl(0 0% 98%);
+    --color-card: hsl(240 10% 3.9%);
+    --color-card-foreground: hsl(0 0% 98%);
+    --color-chart-1: hsl(220 70% 50%);
+    --color-chart-2: hsl(160 60% 45%);
+    --color-chart-3: hsl(30 80% 55%);
+    --color-chart-4: hsl(280 65% 60%);
+    --color-chart-5: hsl(340 75% 55%);
+  }
 }
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border;
   }
   body {
     @apply bg-background text-foreground;
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+      sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,8 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
+  darkMode: 'media',
+  plugins: [
+    require('tailwindcss-animate'),
+  ],
 }


### PR DESCRIPTION
## Summary
issue #1 で報告された shadcn/ui と Tailwind CSS のスタイリング問題を修正

## 主な変更点
- **CSS設定の修正**: `@import "tailwindcss"` を使用し、`@theme` ブロックで色変数を定義
- **アニメーションライブラリの更新**: `tw-animate-css` → `tailwindcss-animate` に変更
- **盤面の枠線**: 常時太い黒枠を表示
- **出口ブロック**: 背景色と枠線を削除
- **駒のサイズ調整**: 駒間の隙間を削除（gap = 0）
- **ハンドルとボタンの色調整**: より淡い色で視認性を向上

## Test plan
- [x] 開発サーバーでスタイルが正しく適用されることを確認
- [x] リンターとタイプチェックが通ることを確認
- [x] ゲームの操作が正常に動作することを確認
- [x] ボタンとハンドルの色が適切に表示されることを確認

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)