### PR TITLE
feat: PR プレビューデプロイメント機能の追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
+
 jobs:
   # Detect which files have changed to determine if we need to run CI
   changes:
@@ -79,6 +85,122 @@ jobs:
       with:
         name: dist
         path: dist/
+
+  # Deploy PR preview (only on PRs with Node 20.x)
+  pr-preview:
+    name: Deploy PR Preview
+    runs-on: ubuntu-latest
+    needs: [changes, test]
+    if: |
+      github.event_name == 'pull_request' && 
+      needs.changes.outputs.app == 'true'
+    
+    # Use shared concurrency group for all deployments
+    concurrency:
+      group: "github-pages-deployment"
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with PR-specific base path
+        run: |
+          # Create a temporary vite config for PR preview
+          cat > vite.config.pr.ts << 'EOF'
+          import { defineConfig } from 'vite'
+          import react from '@vitejs/plugin-react'
+          import path from 'path'
+
+          export default defineConfig({
+            plugins: [react()],
+            base: '/hakoiri-musume/pr-${{ github.event.pull_request.number }}/',
+            resolve: {
+              alias: {
+                '@': path.resolve(__dirname, './src'),
+              },
+            },
+          })
+          EOF
+          
+          # Build with the PR-specific config
+          npx vite build --config vite.config.pr.ts
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Deploy to PR subdirectory
+        run: |
+          # Create PR-specific directory
+          mkdir -p gh-pages/pr-${{ github.event.pull_request.number }}
+          
+          # Copy built files to PR directory
+          cp -r dist/* gh-pages/pr-${{ github.event.pull_request.number }}/
+          
+          # Commit and push
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Deploy PR #${{ github.event.pull_request.number }} preview" || echo "No changes to commit"
+          git push
+
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = context.payload.pull_request.number;
+            const preview_url = `https://koizuka.github.io/hakoiri-musume/pr-${pr_number}/`;
+            
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('<!-- PR Preview Comment -->')
+            );
+            
+            const commentBody = `<!-- PR Preview Comment -->
+            ## 🚀 Preview Deployed!
+            
+            Your preview is available at: ${preview_url}
+            
+            > This preview will be automatically removed when the PR is closed.
+            `;
+            
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody,
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body: commentBody,
+              });
+            }
 
   # Summary job that provides a single status check for branch protection
   ci-summary:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "github-pages-deployment"
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,41 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+# Use shared concurrency group for all deployments
+concurrency:
+  group: "github-pages-deployment"
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Remove PR Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          
+      - name: Remove PR preview directory
+        run: |
+          # Remove the PR-specific directory
+          if [ -d "pr-${{ github.event.pull_request.number }}" ]; then
+            rm -rf pr-${{ github.event.pull_request.number }}
+            
+            # Commit and push
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -m "Remove PR #${{ github.event.pull_request.number }} preview"
+            git push
+            
+            echo "✅ PR preview removed successfully"
+          else
+            echo "ℹ️ No preview directory found for PR #${{ github.event.pull_request.number }}"
+          fi


### PR DESCRIPTION
## 概要
Pull Request ごとに一時的なプレビュー環境を GitHub Pages にデプロイする機能を追加しました。

## 変更内容

### 新機能
- **PR プレビューデプロイメント**: 各 PR に対して専用のサブディレクトリ（`/hakoiri-musume/pr-{番号}/`）にデプロイ
- **自動クリーンアップ**: PR がクローズされると自動的にプレビューを削除
- **PR コメント**: デプロイ完了時にプレビュー URL を PR にコメント

### ワークフローの変更

#### `.github/workflows/deploy.yml`
- concurrency グループを `"pages"` から `"github-pages-deployment"` に変更
- すべてのデプロイで共通の concurrency グループを使用

#### `.github/workflows/ci.yml`
- PR プレビューデプロイメント機能を統合
- PR の場合のみ、テスト成功後にプレビューをデプロイ
- 共通の concurrency グループ `"github-pages-deployment"` を使用

#### `.github/workflows/pr-cleanup.yml` (新規)
- PR クローズ時に自動実行
- 該当する PR のプレビューディレクトリを削除
- 共通の concurrency グループを使用してデプロイの競合を防止

### 技術的な詳細

- **Concurrency 制御**: すべてのデプロイ関連ワークフローで同じ concurrency グループを使用し、デプロイが順番に実行されるように設定
- **動的 base path**: PR ごとに異なる base path でビルドすることで、各 PR が独立したプレビューを持つ
- **本番への影響なし**: 既存の本番デプロイメントフローは変更なし

## テスト計画
- [ ] この PR 自体でプレビューデプロイが作成されることを確認
- [ ] プレビュー URL が正しく動作することを確認
- [ ] PR クローズ時にプレビューが削除されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)