### PR TITLE
ui: 操作説明のレイアウトを改善

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -185,9 +185,14 @@ export function GameBoard({
       </div>
 
       {/* Instructions */}
-      <div className="text-sm text-gray-600 text-center max-w-md">
-        <p>矢印キー: 駒を移動 | スペース: 候補切り替え | U: アンドゥ | ESC: リセット</p>
-        <p>または、駒の矢印をクリックして移動</p>
+      <div className="text-sm text-gray-600 text-center max-w-2xl">
+        <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+          <span>矢印キー: 駒を移動</span>
+          <span>スペース: 候補切り替え</span>
+          <span>U: アンドゥ</span>
+          <span>ESC: リセット</span>
+        </div>
+        <p className="mt-2">または、駒の矢印をクリックして移動</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## 変更内容

盤面下部の操作説明のレイアウトを改善しました。

### 変更点

- **横並びレイアウト**: `flex flex-wrap justify-center`を使用して、各操作説明を横に並べました
- **適切な間隔**: `gap-x-4 gap-y-1`で水平・垂直の間隔を調整
- **幅の拡張**: `max-w-2xl`に変更してより広いスペースを確保
- **構造の改善**: キーボード操作とマウス操作を分離し、マウス操作説明に適切なマージンを追加

### 効果

- 画面幅に応じて自然に折り返しながら、各操作説明が見やすく配置されます
- 従来の縦並びから横並びに変更することで、より整理された印象を与えます

## テスト結果

✅ TypeScript: 型チェック通過
✅ ESLint: コードスタイル検査通過  
✅ Vitest: 全43テスト通過
✅ Build: 本番ビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)