### PR TITLE
fix: 今動かした駒が同じ方向に動ける場合の優先選択を修正

### DIFF
--- a/src/lib/keyboardMapping.ts
+++ b/src/lib/keyboardMapping.ts
@@ -64,24 +64,28 @@ export function updateKeyboardMapping(pieces: Piece[], lastMovedPieceId?: string
         const piecesInDirection = mapping[directionKey];
         
         if (piecesInDirection.length > 1) {
-          // Find the piece that can fill the space left by the last moved piece
-          const fillerPiece = findFillerPiece(pieces, lastMovedPieceId, lastMoveDirection, directionKey);
+          // Check if the last moved piece can move in the current direction
+          const movedPieceIndex = piecesInDirection.indexOf(lastMovedPieceId);
           
-          if (fillerPiece) {
-            // Move the filler piece to the front
-            const fillerIndex = piecesInDirection.indexOf(fillerPiece);
-            if (fillerIndex > 0) {
-              piecesInDirection.splice(fillerIndex, 1);
-              piecesInDirection.unshift(fillerPiece);
-              mapping.selectedIndex[directionKey] = 0;
-            }
-          } else {
-            // If no filler piece, prioritize the last moved piece for auto-undo
-            const movedPieceIndex = piecesInDirection.indexOf(lastMovedPieceId);
+          if (movedPieceIndex >= 0) {
+            // Prioritize the last moved piece if it can move in the current direction
             if (movedPieceIndex > 0) {
               piecesInDirection.splice(movedPieceIndex, 1);
               piecesInDirection.unshift(lastMovedPieceId);
-              mapping.selectedIndex[directionKey] = 0;
+            }
+            mapping.selectedIndex[directionKey] = 0;
+          } else {
+            // If the last moved piece cannot move in this direction, find the filler piece
+            const fillerPiece = findFillerPiece(pieces, lastMovedPieceId, lastMoveDirection, directionKey);
+            
+            if (fillerPiece) {
+              // Move the filler piece to the front
+              const fillerIndex = piecesInDirection.indexOf(fillerPiece);
+              if (fillerIndex > 0) {
+                piecesInDirection.splice(fillerIndex, 1);
+                piecesInDirection.unshift(fillerPiece);
+                mapping.selectedIndex[directionKey] = 0;
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- 駒を動かした後のハンドル優先候補のロジックを改善
- 今動かした駒が同じ方向に動ける場合は、その駒を優先選択するように修正
- 今動かした駒が動けない場合のみ、フィラーピースを優先選択

## Test plan
- [x] TypeScript type checking passed
- [x] Linting passed  
- [x] All tests (43) passed
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.ai/code)