### PR TITLE
fix: WinModalでブラウザAPIガードを追加してCIエラーを修正

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,7 +67,7 @@ describe('App WinModal Display Logic', () => {
     fireEvent.click(screen.getByText('閉じる'))
     await waitFor(() => {
       expect(screen.queryByText('おめでとうございます！')).not.toBeInTheDocument()
-    }, { timeout: 300 })
+    }, { timeout: 500 })
     
     // Game continues: isWon = true -> false, modal should stay hidden
     mockUseGameEngine.mockReturnValue({

--- a/src/components/WinModal.tsx
+++ b/src/components/WinModal.tsx
@@ -15,26 +15,39 @@ export function WinModal({ isOpen, moves, onReset, onClose }: WinModalProps) {
   const [shouldRender, setShouldRender] = useState(false);
 
   useEffect(() => {
+    const isBrowser = typeof window !== 'undefined';
+    if (!isBrowser) return;
+
     if (isOpen) {
       setShouldRender(true);
       // 次のフレームでアニメーションを開始
-      setTimeout(() => setIsVisible(true), 10);
+      const visibilityTimeout = setTimeout(() => setIsVisible(true), 10);
       
       // モーダル内の「閉じる」ボタンにフォーカス
-      setTimeout(() => {
+      const focusTimeout = setTimeout(() => {
         if (closeButtonRef.current) {
           closeButtonRef.current.focus();
         }
       }, 150);
+
+      return () => {
+        clearTimeout(visibilityTimeout);
+        clearTimeout(focusTimeout);
+      };
     } else {
       setIsVisible(false);
       // アニメーション完了後にアンマウント
-      setTimeout(() => setShouldRender(false), 200);
+      const unmountTimeout = setTimeout(() => setShouldRender(false), 200);
+      
+      return () => {
+        clearTimeout(unmountTimeout);
+      };
     }
   }, [isOpen]);
 
   useEffect(() => {
-    if (!shouldRender) return;
+    const isBrowser = typeof document !== 'undefined';
+    if (!isBrowser || !shouldRender) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary

- CI/テスト環境で発生していた「window is not defined」エラーを修正
- WinModalコンポーネントのブラウザAPI使用箇所に存在確認を追加
- タイムアウトの適切なクリーンアップを実装

## Changes

- `useEffect`内でブラウザAPI（`window`, `document`）の存在確認を追加
- `setTimeout`のクリーンアップ関数を実装してメモリリークを防止
- テストの`waitFor`タイムアウト値を300ms→500msに調整

## Test plan

- [x] `npm run typecheck` - TypeScriptの型チェック通過
- [x] `npm run lint` - ESLintチェック通過  
- [x] `npm run test` - 全46テスト通過
- [x] `npm run build` - プロダクションビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)