### PR TITLE
feat: スマホ操作性向上のためレイアウトを改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,14 +44,6 @@ function App() {
         </h1>
         
         <div className="flex flex-col items-center gap-8">
-          <GameControls
-            moves={gameState.moves}
-            canUndo={gameState.moveHistory.length > 0}
-            isWon={gameState.isWon}
-            onUndo={undoMove}
-            onReset={handleReset}
-          />
-          
           <GameBoard
             gameState={gameState}
             onMove={movePiece}
@@ -64,6 +56,25 @@ function App() {
             onShowHandles={showHandlesFunc}
             onToggleHandles={toggleHandles}
           />
+          
+          <GameControls
+            moves={gameState.moves}
+            canUndo={gameState.moveHistory.length > 0}
+            isWon={gameState.isWon}
+            onUndo={undoMove}
+            onReset={handleReset}
+          />
+          
+          {/* Instructions */}
+          <div className="text-sm text-gray-600 text-center max-w-2xl">
+            <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+              <span>矢印キー: 駒を移動</span>
+              <span>スペース: 候補切り替え</span>
+              <span>U: アンドゥ</span>
+              <span>ESC: リセット</span>
+            </div>
+            <p className="mt-2">または、駒の矢印をクリックして移動</p>
+          </div>
         </div>
       </div>
 

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -201,17 +201,6 @@ export function GameBoard({
           );
         })}
       </div>
-
-      {/* Instructions */}
-      <div className="text-sm text-gray-600 text-center max-w-2xl">
-        <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
-          <span>矢印キー: 駒を移動</span>
-          <span>スペース: 候補切り替え</span>
-          <span>U: アンドゥ</span>
-          <span>ESC: リセット</span>
-        </div>
-        <p className="mt-2">または、駒の矢印をクリックして移動</p>
-      </div>
     </div>
   );
 }

--- a/src/components/GameControls.tsx
+++ b/src/components/GameControls.tsx
@@ -26,20 +26,6 @@ export function GameControls({ moves, canUndo, isWon, onUndo, onReset }: GameCon
 
       <div className="flex items-center justify-center space-x-8">
         <Button
-          onClick={onUndo}
-          disabled={!canUndo}
-          variant={canUndo ? "default" : "outline"}
-          size="lg"
-          className={cn(
-            "mr-4",
-            canUndo ? "border-2 border-black" : ""
-          )}
-        >
-          <span>↶</span>
-          アンドゥ (U)
-        </Button>
-
-        <Button
           onClick={onReset}
           variant="default"
           size="lg"
@@ -47,6 +33,19 @@ export function GameControls({ moves, canUndo, isWon, onUndo, onReset }: GameCon
         >
           <span>⟲</span>
           リセット
+        </Button>
+
+        <Button
+          onClick={onUndo}
+          disabled={!canUndo}
+          variant={canUndo ? "default" : "outline"}
+          size="lg"
+          className={cn(
+            canUndo ? "border-2 border-black" : ""
+          )}
+        >
+          <span>↶</span>
+          アンドゥ (U)
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- GameControlsを盤面の下に移動してスマホでの操作しやすさを向上
- ボタン配置を変更（左: リセット、右: アンドゥ）で直感的な操作を実現
- 操作説明をGameControlsの下に移動してUI階層を最適化

## Test plan
- [x] TypeScript型チェック通過
- [x] ESLint検証通過
- [x] テストスイート全通過（46テスト）
- [x] 本番ビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)