### PR TITLE
feat: インストラクションのキー名をキーボードキートップ風デザインに変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useGameEngine } from './hooks/useGameEngine'
 import { GameBoard } from './components/GameBoard'
 import { GameControls } from './components/GameControls'
 import { WinModal } from './components/WinModal'
+import { Kbd } from './components/Kbd'
 
 function App() {
   const [showWinModal, setShowWinModal] = useState(false)
@@ -67,11 +68,23 @@ function App() {
           
           {/* Instructions */}
           <div className="text-sm text-gray-600 text-center max-w-2xl">
-            <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
-              <span>矢印キー: 駒を移動</span>
-              <span>スペース: 候補切り替え</span>
-              <span>U: アンドゥ</span>
-              <span>ESC: リセット</span>
+            <div className="flex flex-wrap justify-center items-center gap-x-6 gap-y-2">
+              <span className="flex items-center gap-2">
+                <Kbd>↑</Kbd><Kbd>↓</Kbd><Kbd>←</Kbd><Kbd>→</Kbd>
+                <span>駒を移動</span>
+              </span>
+              <span className="flex items-center gap-2">
+                <Kbd>Space</Kbd>
+                <span>候補切り替え</span>
+              </span>
+              <span className="flex items-center gap-2">
+                <Kbd>U</Kbd>
+                <span>アンドゥ</span>
+              </span>
+              <span className="flex items-center gap-2">
+                <Kbd>ESC</Kbd>
+                <span>リセット</span>
+              </span>
             </div>
             <p className="mt-2">または、駒の矢印をクリックして移動</p>
           </div>

--- a/src/components/Kbd.tsx
+++ b/src/components/Kbd.tsx
@@ -1,0 +1,13 @@
+import { type ReactNode } from 'react'
+
+interface KbdProps {
+  children: ReactNode
+}
+
+export function Kbd({ children }: KbdProps) {
+  return (
+    <kbd className="inline-flex items-center justify-center px-2 py-1 min-w-[2rem] h-7 font-mono text-xs font-semibold text-gray-700 bg-gray-100 border border-gray-300 rounded-md shadow-[0_2px_0_0_rgba(0,0,0,0.1)] dark:text-gray-300 dark:bg-gray-800 dark:border-gray-600 dark:shadow-[0_2px_0_0_rgba(255,255,255,0.1)]">
+      {children}
+    </kbd>
+  )
+}


### PR DESCRIPTION
## Summary
- ゲームのインストラクション部分のキー名表示を、実際のキーボードキートップのような見た目にデザイン変更
- 新規Kbdコンポーネントを作成し、立体的で視覚的にわかりやすいキー表示を実現
- ダークモード対応済み

## Changes
### 新規コンポーネント
- `src/components/Kbd.tsx`: キーボードキー風の見た目を提供するコンポーネント
  - 3D効果のある影とボーダー
  - モノスペースフォントで統一感のある表示
  - ライト/ダークモード両対応

### 既存ファイルの変更
- `src/App.tsx`: インストラクション部分を更新
  - プレーンテキストからKbdコンポーネントに置き換え
  - 矢印キーを実際の記号（↑↓←→）で表示
  - より見やすいレイアウトに調整

## Test plan
- [x] npm run typecheck - 成功
- [x] npm run lint - 成功  
- [x] npm run test - 成功（47 tests passed）
- [x] npm run build - 成功
- [x] ブラウザでの動作確認（ライトモード）
- [x] ブラウザでの動作確認（ダークモード）

🤖 Generated with [Claude Code](https://claude.ai/code)