### PR TITLE
fix: CI pr-preview jobで変更がない場合のエラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           path: gh-pages
 
       - name: Deploy to PR subdirectory
+        id: deploy
         run: |
           # Create PR-specific directory
           mkdir -p gh-pages/pr/${{ github.event.pull_request.number }}
@@ -174,10 +175,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Deploy PR #${{ github.event.pull_request.number }} preview"
-          git push
+          
+          # Check if there are any changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to deploy - preview is already up to date"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "Deploy PR #${{ github.event.pull_request.number }} preview"
+            git push
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Wait for GitHub Pages deployment
+        if: steps.deploy.outputs.has_changes == 'true'
         run: sleep 60
 
       - name: Update PR Comment with Preview URL


### PR DESCRIPTION
## Summary
- CI workflowのpr-previewジョブで、PRをrebaseしただけなどビルド結果に変更がない場合のエラーを修正
- `git diff --staged`で変更の有無をチェックし、変更がない場合は正常終了として処理
- GitHub Pages deploymentの60秒待機も変更がある場合のみ実行するように改善

## Test plan
- [x] npm run typecheck - 成功
- [x] npm run lint - 成功  
- [x] npm test - 成功
- [x] npm run build - 成功

## 詳細
PRをrebaseした際など、ビルド結果に変更がない場合に`git commit`が「nothing to commit」でエラーになる問題を修正しました。

変更内容:
1. Deploy stepに`id: deploy`を追加してoutput変数を設定可能に
2. `git add`後に`git diff --staged --quiet`で変更有無をチェック
3. 変更がある場合: 通常通りcommit & push、`has_changes=true`を出力
4. 変更がない場合: メッセージを出力して正常終了、`has_changes=false`を出力
5. 60秒の待機処理を`has_changes=true`の場合のみ実行

これにより、PRの内容に実質的な変更がない場合でもCIが正常終了するようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)