### PR TITLE
feat: Dependabot設定にパッケージグループを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,48 @@ updates:
     commit-message:
       prefix: "npm"
       include: "scope"
+    groups:
+      # React関連のパッケージ
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@testing-library/react"
+      # Tailwind CSS関連
+      tailwindcss:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tailwindcss-*"
+      # ESLint関連
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+      # Radix UI関連
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+      # TypeScript関連
+      typescript:
+        patterns:
+          - "typescript"
+          - "typescript-eslint"
+      # Vite関連
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+      # Testing関連
+      testing:
+        patterns:
+          - "vitest"
+          - "@testing-library/*"
+          - "jsdom"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Dependabot設定に依存パッケージのグループ化を追加
- 関連するパッケージが一つのPRでまとめて更新されるように改善

## 変更内容
`.github/dependabot.yml`に以下のグループを設定：
- **react**: React本体、react-dom、型定義、testing-library
- **tailwindcss**: Tailwind CSSとその関連パッケージ
- **eslint**: ESLintとプラグイン、typescript-eslint
- **radix-ui**: Radix UIコンポーネント群
- **typescript**: TypeScriptとtypescript-eslint
- **vite**: Viteとそのプラグイン
- **testing**: Vitest、Testing Library、jsdom

## 効果
- 関連パッケージが同時に更新され、依存関係の不整合を防げる
- PRの数が減り、レビューが効率化される
- 特にReactとreact-domのような密接に関連するパッケージの更新が安全になる

## Test plan
✅ TypeScript型チェック: パス
✅ ESLint: エラーなし
✅ テスト実行: 全47テストパス
✅ ビルド: 正常完了

🤖 Generated with [Claude Code](https://claude.ai/code)