### PR TITLE
feat: disable reset button when game is in initial state

### DIFF
--- a/src/components/GameControls.tsx
+++ b/src/components/GameControls.tsx
@@ -27,9 +27,12 @@ export function GameControls({ moves, canUndo, isWon, onUndo, onReset }: GameCon
       <div className="flex items-center justify-center space-x-8">
         <Button
           onClick={onReset}
-          variant="default"
+          disabled={!canUndo}
+          variant={canUndo ? "default" : "outline"}
           size="lg"
-          className="border-2 border-black dark:border-gray-300 bg-white dark:bg-gray-700 text-black dark:text-white hover:bg-gray-100 dark:hover:bg-gray-600"
+          className={cn(
+            canUndo ? "border-2 border-black dark:border-gray-300 bg-white dark:bg-gray-700 text-black dark:text-white hover:bg-gray-100 dark:hover:bg-gray-600" : "dark:border-gray-600 dark:text-gray-400"
+          )}
         >
           <span>⟲</span>
           リセット


### PR DESCRIPTION
## Summary
- Reset button is now disabled when the game is in its initial state (no moves made)
- Reuses existing `canUndo` flag to determine if any moves have been made
- Applies consistent styling with the undo button when disabled

## Changes
- Modified `GameControls.tsx` to disable reset button when `!canUndo`
- Added appropriate disabled styling to match undo button behavior

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass  
- [x] All tests pass (47/47)
- [x] Production build succeeds
- [x] Reset button is disabled on game start
- [x] Reset button becomes enabled after making moves
- [x] Reset button is disabled again after undoing all moves
- [x] Styling is consistent with undo button when disabled

🤖 Generated with [Claude Code](https://claude.ai/code)