### PR TITLE
fix: handle no changes case in main branch deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,5 +125,11 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add .
-        git commit -m "Deploy production build from main branch"
-        git push
+        
+        # Check if there are any changes to commit
+        if git diff --staged --quiet; then
+          echo "No changes to deploy - site is already up to date"
+        else
+          git commit -m "Deploy production build from main branch"
+          git push
+        fi


### PR DESCRIPTION
## Summary
- Fixed deployment workflow failure when commits don't change build artifacts
- Added conditional check to only commit/push when there are actual changes
- Prevents CI errors when PRs contain only non-code changes (e.g., CI config updates)

## Changes
- Modified `.github/workflows/deploy.yml` to check for staged changes before committing
- Uses same pattern as PR preview workflow for consistency

## Test plan
- [x] Pre-checks passed: typecheck, lint, test, build all successful
- [x] Workflow syntax is valid
- [ ] Test with a commit that doesn't change build output to verify no failure

🤖 Generated with [Claude Code](https://claude.ai/code)