### PR TITLE
ci: ジョブを並列化してCI・PR Previewを高速化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs for the same PR/branch so only the latest push runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect which files have changed to determine if we need to run CI
   changes:
@@ -44,48 +49,111 @@ jobs:
               - '.nvmrc'
               - '.github/workflows/ci.yml'
 
-  test:
-    name: Test and Build
+  # Build the app. On PRs, build with the PR-specific base path so the same
+  # artifact deploys straight to the preview — no rebuild in the pr-preview job.
+  build:
+    name: Build
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.app == 'true'
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version-file: .nvmrc
-        cache: 'npm'
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Run type check
-      run: npm run typecheck
+      - name: Build
+        run: npm run build -- --base=${{ github.event_name == 'pull_request' && format('/hakoiri-musume/pr/{0}/', github.event.pull_request.number) || '/hakoiri-musume/' }}
 
-    - name: Run lint
-      run: npm run lint
+      - name: Upload PR preview artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-preview-dist
+          path: dist
+          retention-days: 1
+          if-no-files-found: error
 
-    - name: Run tests
-      run: npm test
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
 
-    - name: Build
-      run: npm run build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: dist
-        path: dist/
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
 
-  # Deploy PR preview (only on PRs with Node 20.x)
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npm run typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  # Deploy PR preview. Depends only on `build`: the preview goes up as soon as
+  # the app builds, without waiting for lint/typecheck/test.
   pr-preview:
     name: Deploy PR Preview
     runs-on: ubuntu-latest
-    needs: [changes, test]
+    needs: [changes, build]
     if: |
       github.event_name == 'pull_request' &&
       needs.changes.outputs.app == 'true'
@@ -115,43 +183,12 @@ jobs:
             echo "PR #${{ github.event.pull_request.number }} is $state. Skipping preview deploy."
           fi
 
-      - name: Checkout PR
+      - name: Download build artifact
         if: steps.pr-state.outputs.open == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        if: steps.pr-state.outputs.open == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          node-version-file: .nvmrc
-          cache: 'npm'
-
-      - name: Install dependencies
-        if: steps.pr-state.outputs.open == 'true'
-        run: npm ci
-
-      - name: Build with PR-specific base path
-        if: steps.pr-state.outputs.open == 'true'
-        run: |
-          # Create a temporary vite config for PR preview
-          cat > vite.config.pr.ts << 'EOF'
-          import { defineConfig } from 'vite'
-          import react from '@vitejs/plugin-react'
-          import path from 'path'
-
-          export default defineConfig({
-            plugins: [react()],
-            base: '/hakoiri-musume/pr/${{ github.event.pull_request.number }}/',
-            resolve: {
-              alias: {
-                '@': path.resolve(__dirname, './src'),
-              },
-            },
-          })
-          EOF
-
-          # Build with the PR-specific config
-          npx vite build --config vite.config.pr.ts
+          name: pr-preview-dist
+          path: dist
 
       - name: Deploy PR Preview
         if: steps.pr-state.outputs.open == 'true'
@@ -271,32 +308,36 @@ jobs:
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [changes, test]
+    needs: [changes, build, lint, typecheck, test]
     if: always()
 
     steps:
       - name: Check CI Results
         run: |
           echo "Checking CI results..."
-          echo "App changes: ${{ needs.changes.outputs.app }}"
+          echo "App changes:     ${{ needs.changes.outputs.app }}"
+          echo "Build result:    ${{ needs.build.result }}"
+          echo "Lint result:     ${{ needs.lint.result }}"
+          echo "Typecheck result: ${{ needs.typecheck.result }}"
+          echo "Test result:     ${{ needs.test.result }}"
 
           # Check if any tests were supposed to run
           if [[ "${{ needs.changes.outputs.app }}" == "true" ]]; then
             echo "Tests were executed. Checking results..."
-            
+
             # Check if any job failed
             if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-              echo "❌ CI failed: One or more tests failed"
+              echo "❌ CI failed: One or more jobs failed"
               exit 1
             fi
-            
+
             # Check if any job was cancelled
             if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
               echo "⚠️ CI cancelled: One or more jobs were cancelled"
               exit 1
             fi
-            
-            echo "✅ All tests passed!"
+
+            echo "✅ All checks passed!"
           else
             echo "✅ No code changes detected - skipping tests"
           fi


### PR DESCRIPTION
## 概要

直列実行だった単一の `test` ジョブを独立した並列ジョブに分割し、CI と PR Preview の完了時間を短縮します。設計は `../drawing-practice` の `test.yml` を参考にしています。

### Before

```
changes → test (npm ci → typecheck → lint → test → build を直列実行)
              → pr-preview (再 checkout → npm ci → 一時 vite.config.pr.ts 生成 → 再ビルド → デプロイ)
```

### After

```
changes ─┬─ build      (npm ci → build --base=<PR用パス> → artifact アップロード)
         ├─ lint       (npm ci → lint)
         ├─ typecheck  (npm ci → typecheck)
         ├─ test       (npm ci → test)
         └─ audit      (変更なし)

pr-preview  needs [changes, build]  → artifact ダウンロード → デプロイのみ
ci-summary  needs [changes, build, lint, typecheck, test]
```

## 変更点

- **`test` ジョブを4並列ジョブに分割** — 体感完了時間が「直列の合計」から「`npm ci` + 最も遅い1タスク」に短縮
- **`build` で一度だけビルド** — `npm run build -- --base=...` でPR時は `/hakoiri-musume/pr/{番号}/`、push時は `/hakoiri-musume/` を指定。`dist` を `pr-preview-dist` artifact としてアップロード（PR時のみ、retention 1日）
- **`pr-preview` は artifact をダウンロードしてデプロイするのみ** — 再 checkout・`npm ci`・一時 `vite.config.pr.ts` 生成・再ビルドを廃止。`needs: [changes, build]` のみに依存し、`build` 完了直後にプレビューが公開される。PRクローズ時のスキップ判定と `github-pages-deployment` 共有 concurrency は維持
- **workflow レベルの `concurrency` + `cancel-in-progress: true` を追加** — 連続 push 時に古い run を自動キャンセル
- **`ci-summary` の `needs`** を分割後の全ジョブに更新

## 動作上の注意

- **`pr-preview` は `build` のみに依存** — lint/test の完了を待たずプレビューを公開するため、lint/test が失敗してもプレビューはデプロイされます（プレビューを早く出すことを優先。`drawing-practice` と同じ挙動）
- **ジョブ名の変更** — `Test and Build` → `Build` / `Lint` / `Type Check` / `Test`。✅ リポジトリのルールセット「main」の必須ステータスチェックは `CI Summary` のみで、このジョブ名は不変のため対応不要であることを確認済み（`ci-summary` が全ジョブを `needs` で集約するため保護は従来どおり機能）

## テスト

ローカルでプリチェックを実行し全て成功:

- ✅ `npm run typecheck`
- ✅ `npm run lint` (0 errors / 既存 warning 1件、本変更とは無関係)
- ✅ `npm run test` (47 tests passed)
- ✅ `npm run build`
- ✅ `actionlint .github/workflows/ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)