### PR TITLE
chore(ci): .nvmrc 変更を npm cache key に反映

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -97,6 +100,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -119,6 +125,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -141,6 +150,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            .nvmrc
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,9 @@ jobs:
       with:
         node-version-file: .nvmrc
         cache: 'npm'
+        cache-dependency-path: |
+          package-lock.json
+          .nvmrc
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
## Summary

`actions/setup-node` の組み込み npm cache key は `cache-dependency-path` のハッシュからしか算出されず、`node-version-file` (`.nvmrc`) は反映されない。そのため `.nvmrc` を更新しても古い Node バージョン向けの npm cache がヒットしてしまい、依存解決の前提とずれる可能性がある。

`cache-dependency-path` に `package-lock.json` と `.nvmrc` を併記することで、Node バージョン更新時に cache key が変わり cache miss → 再構築されるようにする。

- **ci.yml**: `build` / `lint` / `typecheck` / `test` の 4 ジョブに `cache-dependency-path` を追加
- **deploy.yml**: `build` ジョブに `cache-dependency-path` を追加

### 変更不要な箇所

- `ci.yml` の `audit` ジョブは `cache:` 未指定 (`--package-lock-only` で install しない) ため対象外
- paths-filter / push paths 側は両 workflow とも既に `.nvmrc` を含むのでトリガ漏れは無し

参考: [koizuka/drawing-practice#184](https://github.com/koizuka/drawing-practice/pull/184)

## Test plan

- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm run test` パス
- [x] `npm run build` パス
- [x] 本 PR の CI が build / lint / typecheck / test すべて成功すること
- [ ] (次回 `.nvmrc` 更新 PR で) setup-node のログ上 cache key が前回と異なり cache miss となること

🤖 Generated with [Claude Code](https://claude.com/claude-code)