### PR TITLE
ci: PR-Preview デプロイのキャンセルを queue: max で解消(全件直列実行)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
     concurrency:
       group: "github-pages-deployment"
       cancel-in-progress: false
+      queue: max
 
     steps:
       - name: Skip deploy if PR is already closed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ permissions:
 concurrency:
   group: "github-pages-deployment"
   cancel-in-progress: false
+  queue: max
 
 jobs:
   # Detect which files have changed to determine if we need to deploy

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -12,6 +12,7 @@ permissions:
 concurrency:
   group: "github-pages-deployment"
   cancel-in-progress: false
+  queue: max
 
 jobs:
   cleanup:


### PR DESCRIPTION
## 概要

複数の PR(特に Dependabot がまとめて上げる更新)がほぼ同時に CI を起動すると、共有 concurrency group `github-pages-deployment` の既定 `queue: single` により待機列が 1 件しか保持されず、一部の PR-Preview デプロイジョブが `cancelled` になる問題を解消する。

`cancel-in-progress: false` の 3 ブロックに `queue: max` を追加し、pending を FIFO で最大 100 件まで保持して全 PR の preview を順次デプロイできるようにする。排他制御(同一 gh-pages への直列デプロイ)は維持したまま、待機列をキャンセルしない。

Closes #245

## 変更箇所(各 1 行追加)

- `.github/workflows/ci.yml` — `pr-preview` ジョブの job-level concurrency
- `.github/workflows/deploy.yml` — workflow-level concurrency
- `.github/workflows/pr-cleanup.yml` — workflow-level concurrency

```yaml
concurrency:
  group: "github-pages-deployment"
  cancel-in-progress: false
  queue: max          # <-- 追加
```

`ci.yml` の workflow-level concurrency(別グループ・`cancel-in-progress: true`)は本バグと無関係なため変更していない(`queue: max` は `cancel-in-progress: true` と併用すると validation error になる)。

> 参照: countdown-torch で同じ修正を実施済み → koizuka/countdown-torch#162 (commit `d581588`)

## テスト結果

- ✅ `npm run typecheck`
- ✅ `npm run lint`(既存の警告 1 件のみ、本変更と無関係)
- ✅ `npm run test`(47 passed)
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)