### PR TITLE
fix: remove unused eslint-disable directive in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,6 @@ function App() {
 
   useEffect(() => {
     if (gameState.isWon && !prevIsWonRef.current) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setShowWinModal(true)
     }
 


### PR DESCRIPTION
## 概要

`src/App.tsx` の `useEffect` 内にあった不要な `eslint-disable-next-line react-hooks/set-state-in-effect` コメントを削除しました。

このルールはもう問題を報告しなくなっており、ESLint が「Unused eslint-disable directive」の warning を出していたため、該当コメントを削除して lint warning を解消します。

## テスト結果

- ✅ `npm run typecheck`
- ✅ `npm run lint`（warning 解消）
- ✅ `npm run test`（47 tests passed）
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)